### PR TITLE
Change `wait-for-it` script location.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN bash /tmp/consul_template_install.sh && rm /tmp/consul_template_install.sh
 RUN groupadd $SERVICE_USER && useradd --create-home --home $SERVICE_ROOT --gid $SERVICE_USER --shell /bin/bash $SERVICE_USER
 WORKDIR $SERVICE_ROOT
 
-ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh $SERVICE_ROOT/wait-for-it.sh
-RUN chmod a+rx $SERVICE_ROOT/wait-for-it.sh
+ADD https://raw.githubusercontent.com/articulate/docker-consul-template-bootstrap/master/wait-for-it.sh /wait-for-it.sh
+RUN chmod a+rx /wait-for-it.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
I ran into problems consuming this in the `rise-business-content` service - the `wait-for-it` script was being trampled in `$SERVICE_ROOT` by my service's app folder being volumed in.

I believe we want the `wait-for-it` shell script to be placed outside of the `$SERVICE_ROOT` folder, as we've done with our node image, unless I'm missing a more preferable solution.