### PR TITLE
Change 1.13 to hexpm's docker image

### DIFF
--- a/1.13/Dockerfile
+++ b/1.13/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.13-otp-25-slim
+FROM hexpm/elixir:1.13.4-erlang-25.0.4-debian-bullseye-20220801-slim
 
 ENV SERVICE_ROOT /service
 ENV SERVICE_USER service


### PR DESCRIPTION

## New Image Checklist
 Try to fix issues building by switching to hexpm's docker image
